### PR TITLE
Adding missing dash to npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add -D csv-loader
 Install with npm:
 
 ```
-npm install -save-dev csv-loader
+npm install --save-dev csv-loader
 ```
 
 ## Usage


### PR DESCRIPTION
when the extra dash is missing, users will hit issue with dev dependencies of csv-loader not getting installed correctly. 